### PR TITLE
CI: harden coq-action.yml (split from #37)

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # the OS must be GNU/Linux to be able to use the docker-coq-action
@@ -20,7 +23,7 @@ jobs:
           # - mathcomp/mathcomp:2.3.0-rocq-prover-9.0
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: coq-community/docker-coq-action@v1
       with:
         opam_file: 'coq-validsdp.opam'


### PR DESCRIPTION
Split out of #37, per @erikmd's review: `coq-action.yml` is hand-maintained, so it
can land on its own, whereas the `nix-action-*.yml` files in #37 are
coq-nix-toolbox—generated and must not be hand-edited. #37 will be rebuilt as a
regenerated-only change.

Two changes, both to `coq-action.yml`:

- `permissions: contents: read` — the workflow otherwise inherits the
  repository's default `GITHUB_TOKEN` scope. It needs nothing beyond reading the
  contents it checks out.
- `actions/checkout@v2` → `@v4`. v2 runs on the Node 12 runtime, which GitHub
  removed; v2 invocations are force-upgraded at runtime and warn.

The workflow references no secrets, so neither change can affect what it is able
to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9BGQT7XUuubV6C619DW4b
